### PR TITLE
Password is not set when going through the password grant flow

### DIFF
--- a/src/OAuth.AspNet.AuthServer/OAuth/AspNet/AuthServer/TokenEndpointRequest.cs
+++ b/src/OAuth.AspNet.AuthServer/OAuth/AspNet/AuthServer/TokenEndpointRequest.cs
@@ -75,7 +75,7 @@ namespace OAuth.AspNet.AuthServer
                 parameters.TryGetValue(Constants.Parameters.Username, out usernameValue);
 
                 StringValues passwordValue;
-                parameters.TryGetValue(Constants.Parameters.Scope, out passwordValue);
+                parameters.TryGetValue(Constants.Parameters.Password, out passwordValue);
 
                 StringValues scopeValue;
                 parameters.TryGetValue(Constants.Parameters.Scope, out scopeValue);


### PR DESCRIPTION
When handling an auth request that has a grant type of password, the password is attempted to be extracted from the input parameters from the request body using the `Constants.Parameters.Scope` constant instead of `Constants.Parameters.Password`.